### PR TITLE
Improved stripping of script and noscript tags.

### DIFF
--- a/jquery.autopager-too.js
+++ b/jquery.autopager-too.js
@@ -151,9 +151,24 @@
     }
   }
 
+  function stripTag(s, tagsToRemove) {
+    var index;
+    for (index = 0; index < tagsToRemove.length; index++) {
+      var div = document.createElement('div');
+      div.innerHTML = s;
+      var tags = div.getElementsByTagName(tagsToRemove[index]);
+      var i = tags.length;
+      while (i--) {
+        tags[i].parentNode.removeChild(tags[i]);
+      }
+      s = div.innerHTML;
+    }
+    return s;
+  }
+
   function insertContent(res) {
     var _options = options,
-    nextPage = $('<div/>').append(res.replace(/<script(.|\s)*?\/script>/g, "")),
+      nextPage = $('<div/>').append(stripTag(res, [ "script", "noscript"])),
     nextContent = nextPage.find(_options.content); 
 
     set('page', _options.page + 1);


### PR DESCRIPTION
Improved the current removal of script and noscript tags currently done by regular expression to a DOM based approach.
Part of the code was based on function stripScripts found at https://stackoverflow.com/questions/6659351/removing-all-script-tags-from-html-with-js-regular-expression

```
  function stripScripts(s) {
    var div = document.createElement('div');
    div.innerHTML = s;
    var scripts = div.getElementsByTagName('script');
    var i = scripts.length;
    while (i--) {
      scripts[i].parentNode.removeChild(scripts[i]);
    }
    return div.innerHTML;
  }

alert(
 stripScripts('<span><script type="text/javascript">alert(\'foo\');<\/script><\/span>')
);
```